### PR TITLE
Feature/interaction blocking

### DIFF
--- a/Assets/Demo/Data/UnityScreenNavigatorSettings.asset
+++ b/Assets/Demo/Data/UnityScreenNavigatorSettings.asset
@@ -12,15 +12,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2b15ff60fcf110249b1f95c0fdfe5e8e, type: 3}
   m_Name: UnityScreenNavigatorSettings
   m_EditorClassIdentifier: 
-  _defaultSheetEnterAnimation: {fileID: 0}
-  _defaultSheetExitAnimation: {fileID: 0}
-  _defaultPagePushEnterAnimation: {fileID: 0}
-  _defaultPagePushExitAnimation: {fileID: 0}
-  _defaultPagePopEnterAnimation: {fileID: 0}
-  _defaultPagePopExitAnimation: {fileID: 0}
-  _defaultModalEnterAnimation: {fileID: 0}
-  _defaultModalExitAnimation: {fileID: 0}
-  _defaultModalBackdropEnterAnimation: {fileID: 0}
-  _defaultModalBackdropExitAnimation: {fileID: 0}
-  _defaultModalBackdropPrefab: {fileID: 0}
+  _sheetEnterAnimation: {fileID: 0}
+  _sheetExitAnimation: {fileID: 0}
+  _pagePushEnterAnimation: {fileID: 0}
+  _pagePushExitAnimation: {fileID: 0}
+  _pagePopEnterAnimation: {fileID: 0}
+  _pagePopExitAnimation: {fileID: 0}
+  _modalEnterAnimation: {fileID: 0}
+  _modalExitAnimation: {fileID: 0}
+  _modalBackdropEnterAnimation: {fileID: 0}
+  _modalBackdropExitAnimation: {fileID: 0}
+  _modalBackdropPrefab: {fileID: 0}
   _assetLoader: {fileID: 0}
+  _enableInteractionInTransition: 0
+  _controlInteractionsOfAllContainers: 0

--- a/Assets/UnityScreenNavigator/Runtime/Core/Modal/Modal.cs
+++ b/Assets/UnityScreenNavigator/Runtime/Core/Modal/Modal.cs
@@ -50,12 +50,6 @@ namespace UnityScreenNavigator.Runtime.Core.Modal
 
         public ModalTransitionAnimationContainer AnimationContainer => _animationContainer;
 
-        public bool Interactable
-        {
-            get => _canvasGroup.interactable;
-            set => _canvasGroup.interactable = value;
-        }
-
         public bool IsTransitioning { get; private set; }
 
         /// <summary>
@@ -203,9 +197,6 @@ namespace UnityScreenNavigator.Runtime.Core.Modal
 
             SetTransitionProgress(0.0f);
 
-            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
-                _canvasGroup.interactable = false;
-
             var routines = push
                 ? _lifecycleEvents.Select(x => x.WillPushEnter())
                 : _lifecycleEvents.Select(x => x.WillPopEnter());
@@ -252,9 +243,6 @@ namespace UnityScreenNavigator.Runtime.Core.Modal
                 foreach (var lifecycleEvent in _lifecycleEvents)
                     lifecycleEvent.DidPopEnter();
 
-            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
-                _canvasGroup.interactable = true;
-
             IsTransitioning = false;
             TransitionAnimationType = null;
         }
@@ -276,9 +264,6 @@ namespace UnityScreenNavigator.Runtime.Core.Modal
             }
 
             SetTransitionProgress(0.0f);
-
-            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
-                _canvasGroup.interactable = false;
 
             var routines = push
                 ? _lifecycleEvents.Select(x => x.WillPushExit())

--- a/Assets/UnityScreenNavigator/Runtime/Core/Page/Page.cs
+++ b/Assets/UnityScreenNavigator/Runtime/Core/Page/Page.cs
@@ -52,12 +52,6 @@ namespace UnityScreenNavigator.Runtime.Core.Page
 
         public PageTransitionAnimationContainer AnimationContainer => _animationContainer;
 
-        public bool Interactable
-        {
-            get => _canvasGroup.interactable;
-            set => _canvasGroup.interactable = value;
-        }
-
         public bool IsTransitioning { get; private set; }
 
         /// <summary>
@@ -217,9 +211,6 @@ namespace UnityScreenNavigator.Runtime.Core.Page
             gameObject.SetActive(true);
             _rectTransform.FillParent(_parentTransform);
             SetTransitionProgress(0.0f);
-            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
-                _canvasGroup.interactable = false;
-
             _canvasGroup.alpha = 0.0f;
 
             var routines = push
@@ -264,9 +255,6 @@ namespace UnityScreenNavigator.Runtime.Core.Page
                 foreach (var lifecycleEvent in _lifecycleEvents)
                     lifecycleEvent.DidPopEnter();
 
-            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
-                _canvasGroup.interactable = true;
-
             IsTransitioning = false;
             TransitionAnimationType = null;
         }
@@ -283,9 +271,6 @@ namespace UnityScreenNavigator.Runtime.Core.Page
             gameObject.SetActive(true);
             _rectTransform.FillParent(_parentTransform);
             SetTransitionProgress(0.0f);
-            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
-                _canvasGroup.interactable = false;
-
             _canvasGroup.alpha = 1.0f;
 
             var routines = push

--- a/Assets/UnityScreenNavigator/Runtime/Core/Page/PageContainer.cs
+++ b/Assets/UnityScreenNavigator/Runtime/Core/Page/PageContainer.cs
@@ -3,7 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityScreenNavigator.Runtime.Core.Modal;
 using UnityScreenNavigator.Runtime.Core.Shared;
+using UnityScreenNavigator.Runtime.Core.Sheet;
 using UnityScreenNavigator.Runtime.Foundation;
 using UnityScreenNavigator.Runtime.Foundation.AssetLoader;
 using UnityScreenNavigator.Runtime.Foundation.Coroutine;
@@ -13,6 +15,8 @@ namespace UnityScreenNavigator.Runtime.Core.Page
     [RequireComponent(typeof(RectMask2D))]
     public sealed class PageContainer : MonoBehaviour
     {
+        public static List<PageContainer> Instances { get; } = new List<PageContainer>();
+
         private static readonly Dictionary<int, PageContainer> InstanceCacheByTransform =
             new Dictionary<int, PageContainer>();
 
@@ -66,6 +70,8 @@ namespace UnityScreenNavigator.Runtime.Core.Page
 
         private void Awake()
         {
+            Instances.Add(this);
+            
             _callbackReceivers.AddRange(GetComponents<IPageContainerCallbackReceiver>());
             if (!string.IsNullOrWhiteSpace(_name))
             {
@@ -102,6 +108,8 @@ namespace UnityScreenNavigator.Runtime.Core.Page
             {
                 InstanceCacheByTransform.Remove(keyToRemove);
             }
+
+            Instances.Remove(this);
         }
 
         /// <summary>
@@ -248,6 +256,23 @@ namespace UnityScreenNavigator.Runtime.Core.Page
 
             IsInTransition = true;
 
+            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
+            {
+                if (UnityScreenNavigatorSettings.Instance.ControlInteractionsOfAllContainers)
+                {
+                    foreach (var pageContainer in Instances)
+                        pageContainer.Interactable = false;
+                    foreach (var modalContainer in ModalContainer.Instances)
+                        modalContainer.Interactable = false;
+                    foreach (var sheetContainer in SheetContainer.Instances)
+                        sheetContainer.Interactable = false;
+                }
+                else
+                {
+                    Interactable = false;
+                }
+            }
+
             // Setup
             var assetLoadHandle = loadAsync
                 ? AssetLoader.LoadAsync<GameObject>(resourceKey)
@@ -357,6 +382,23 @@ namespace UnityScreenNavigator.Runtime.Core.Page
             }
 
             _isActivePageStacked = stack;
+
+            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
+            {
+                if (UnityScreenNavigatorSettings.Instance.ControlInteractionsOfAllContainers)
+                {
+                    foreach (var pageContainer in Instances)
+                        pageContainer.Interactable = true;
+                    foreach (var modalContainer in ModalContainer.Instances)
+                        modalContainer.Interactable = true;
+                    foreach (var sheetContainer in SheetContainer.Instances)
+                        sheetContainer.Interactable = true;
+                }
+                else
+                {
+                    Interactable = true;
+                }
+            }
         }
 
         private IEnumerator PopRoutine(bool playAnimation)
@@ -374,6 +416,23 @@ namespace UnityScreenNavigator.Runtime.Core.Page
             }
 
             IsInTransition = true;
+
+            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
+            {
+                if (UnityScreenNavigatorSettings.Instance.ControlInteractionsOfAllContainers)
+                {
+                    foreach (var pageContainer in Instances)
+                        pageContainer.Interactable = false;
+                    foreach (var modalContainer in ModalContainer.Instances)
+                        modalContainer.Interactable = false;
+                    foreach (var sheetContainer in SheetContainer.Instances)
+                        sheetContainer.Interactable = false;
+                }
+                else
+                {
+                    Interactable = false;
+                }
+            }
 
             var exitPage = _pages[_pages.Count - 1];
             var exitPageId = exitPage.GetInstanceID();
@@ -449,6 +508,23 @@ namespace UnityScreenNavigator.Runtime.Core.Page
             _assetLoadHandles.Remove(exitPageId);
 
             _isActivePageStacked = true;
+
+            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
+            {
+                if (UnityScreenNavigatorSettings.Instance.ControlInteractionsOfAllContainers)
+                {
+                    foreach (var pageContainer in Instances)
+                        pageContainer.Interactable = true;
+                    foreach (var modalContainer in ModalContainer.Instances)
+                        modalContainer.Interactable = true;
+                    foreach (var sheetContainer in SheetContainer.Instances)
+                        sheetContainer.Interactable = true;
+                }
+                else
+                {
+                    Interactable = true;
+                }
+            }
         }
 
         public AsyncProcessHandle Preload(string resourceKey, bool loadAsync = true)

--- a/Assets/UnityScreenNavigator/Runtime/Core/Shared/UnityScreenNavigatorSettings.cs
+++ b/Assets/UnityScreenNavigator/Runtime/Core/Shared/UnityScreenNavigatorSettings.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using UnityEngine;
 using UnityScreenNavigator.Runtime.Core.Modal;
+using UnityScreenNavigator.Runtime.Foundation;
 using UnityScreenNavigator.Runtime.Foundation.AssetLoader;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -41,6 +42,9 @@ namespace UnityScreenNavigator.Runtime.Core.Shared
         [SerializeField] private AssetLoaderObject _assetLoader;
 
         [SerializeField] private bool _enableInteractionInTransition;
+
+        [EnabledIf(nameof(_enableInteractionInTransition), false)] [SerializeField]
+        private bool _controlInteractionsOfAllContainers = true;
 
         private IAssetLoader _defaultAssetLoader;
         private ModalBackdrop _defaultModalBackdrop;
@@ -125,7 +129,17 @@ namespace UnityScreenNavigator.Runtime.Core.Shared
             }
         }
 
-        public bool EnableInteractionInTransition => _enableInteractionInTransition;
+        public bool EnableInteractionInTransition
+        {
+            get => _enableInteractionInTransition;
+            set => _enableInteractionInTransition = value;
+        }
+
+        public bool ControlInteractionsOfAllContainers
+        {
+            get => _controlInteractionsOfAllContainers;
+            set => _controlInteractionsOfAllContainers = value;
+        }
 
         public static UnityScreenNavigatorSettings Instance
         {

--- a/Assets/UnityScreenNavigator/Runtime/Core/Sheet/Sheet.cs
+++ b/Assets/UnityScreenNavigator/Runtime/Core/Sheet/Sheet.cs
@@ -49,12 +49,6 @@ namespace UnityScreenNavigator.Runtime.Core.Sheet
 
         public SheetTransitionAnimationContainer AnimationContainer => _animationContainer;
 
-        public bool Interactable
-        {
-            get => _canvasGroup.interactable;
-            set => _canvasGroup.interactable = value;
-        }
-
         public bool IsTransitioning { get; private set; }
 
         /// <summary>
@@ -180,9 +174,6 @@ namespace UnityScreenNavigator.Runtime.Core.Sheet
             _rectTransform.FillParent(_parentTransform);
             SetTransitionProgress(0.0f);
 
-            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
-                _canvasGroup.interactable = false;
-
             _canvasGroup.alpha = 0.0f;
 
             var handle = CoroutineManager.Instance.Run(CreateCoroutine(_lifecycleEvents.Select(x => x.WillEnter())));
@@ -219,9 +210,6 @@ namespace UnityScreenNavigator.Runtime.Core.Sheet
             foreach (var lifecycleEvent in _lifecycleEvents)
                 lifecycleEvent.DidEnter();
 
-            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
-                _canvasGroup.interactable = true;
-
             IsTransitioning = false;
             TransitionAnimationType = null;
         }
@@ -238,8 +226,6 @@ namespace UnityScreenNavigator.Runtime.Core.Sheet
             gameObject.SetActive(true);
             _rectTransform.FillParent(_parentTransform);
             SetTransitionProgress(0.0f);
-            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
-                _canvasGroup.interactable = false;
 
             _canvasGroup.alpha = 1.0f;
 

--- a/Assets/UnityScreenNavigator/Runtime/Core/Sheet/SheetContainer.cs
+++ b/Assets/UnityScreenNavigator/Runtime/Core/Sheet/SheetContainer.cs
@@ -3,6 +3,8 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityScreenNavigator.Runtime.Core.Modal;
+using UnityScreenNavigator.Runtime.Core.Page;
 using UnityScreenNavigator.Runtime.Core.Shared;
 using UnityScreenNavigator.Runtime.Foundation;
 using UnityScreenNavigator.Runtime.Foundation.AssetLoader;
@@ -13,6 +15,8 @@ namespace UnityScreenNavigator.Runtime.Core.Sheet
     [RequireComponent(typeof(RectMask2D))]
     public sealed class SheetContainer : MonoBehaviour
     {
+        public static List<SheetContainer> Instances { get; } = new List<SheetContainer>();
+        
         private static readonly Dictionary<int, SheetContainer> InstanceCacheByTransform =
             new Dictionary<int, SheetContainer>();
 
@@ -78,6 +82,8 @@ namespace UnityScreenNavigator.Runtime.Core.Sheet
 
         private void Awake()
         {
+            Instances.Add(this);
+            
             _callbackReceivers.AddRange(GetComponents<ISheetContainerCallbackReceiver>());
 
             if (!string.IsNullOrWhiteSpace(_name))
@@ -115,6 +121,8 @@ namespace UnityScreenNavigator.Runtime.Core.Sheet
             {
                 InstanceCacheByTransform.Remove(keyToRemove);
             }
+
+            Instances.Remove(this);
         }
 
         /// <summary>
@@ -323,6 +331,23 @@ namespace UnityScreenNavigator.Runtime.Core.Sheet
 
             IsInTransition = true;
 
+            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
+            {
+                if (UnityScreenNavigatorSettings.Instance.ControlInteractionsOfAllContainers)
+                {
+                    foreach (var pageContainer in PageContainer.Instances)
+                        pageContainer.Interactable = false;
+                    foreach (var modalContainer in ModalContainer.Instances)
+                        modalContainer.Interactable = false;
+                    foreach (var sheetContainer in Instances)
+                        sheetContainer.Interactable = false;
+                }
+                else
+                {
+                    Interactable = false;
+                }
+            }
+
             var enterSheet = _sheets[sheetId];
             var exitSheet = _activeSheetId.HasValue ? _sheets[_activeSheetId.Value] : null;
 
@@ -380,6 +405,23 @@ namespace UnityScreenNavigator.Runtime.Core.Sheet
             {
                 callbackReceiver.AfterShow(enterSheet, exitSheet);
             }
+
+            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
+            {
+                if (UnityScreenNavigatorSettings.Instance.ControlInteractionsOfAllContainers)
+                {
+                    foreach (var pageContainer in PageContainer.Instances)
+                        pageContainer.Interactable = true;
+                    foreach (var modalContainer in ModalContainer.Instances)
+                        modalContainer.Interactable = true;
+                    foreach (var sheetContainer in Instances)
+                        sheetContainer.Interactable = true;
+                }
+                else
+                {
+                    Interactable = true;
+                }
+            }
         }
 
         private IEnumerator HideRoutine(bool playAnimation)
@@ -397,6 +439,23 @@ namespace UnityScreenNavigator.Runtime.Core.Sheet
             }
 
             IsInTransition = true;
+
+            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
+            {
+                if (UnityScreenNavigatorSettings.Instance.ControlInteractionsOfAllContainers)
+                {
+                    foreach (var pageContainer in PageContainer.Instances)
+                        pageContainer.Interactable = false;
+                    foreach (var modalContainer in ModalContainer.Instances)
+                        modalContainer.Interactable = false;
+                    foreach (var sheetContainer in Instances)
+                        sheetContainer.Interactable = false;
+                }
+                else
+                {
+                    Interactable = false;
+                }
+            }
 
             var exitSheet = _sheets[_activeSheetId.Value];
 
@@ -428,6 +487,23 @@ namespace UnityScreenNavigator.Runtime.Core.Sheet
             foreach (var callbackReceiver in _callbackReceivers)
             {
                 callbackReceiver.AfterHide(exitSheet);
+            }
+
+            if (!UnityScreenNavigatorSettings.Instance.EnableInteractionInTransition)
+            {
+                if (UnityScreenNavigatorSettings.Instance.ControlInteractionsOfAllContainers)
+                {
+                    foreach (var pageContainer in PageContainer.Instances)
+                        pageContainer.Interactable = true;
+                    foreach (var modalContainer in ModalContainer.Instances)
+                        modalContainer.Interactable = true;
+                    foreach (var sheetContainer in Instances)
+                        sheetContainer.Interactable = true;
+                }
+                else
+                {
+                    Interactable = true;
+                }
             }
         }
     }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -125,7 +125,8 @@ PlayerSettings:
     16:9: 1
     Others: 1
   bundleVersion: 0.1
-  preloadedAssets: []
+  preloadedAssets:
+  - {fileID: 11400000, guid: b1c1d84fee26043b5b2a854185896d81, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/README.md
+++ b/README.md
@@ -869,13 +869,16 @@ Then, check the **Close Modal When Clicked** option of the **Modal Backdrop** co
 </p>
 
 #### Enable interaction during transitions
-From the start of transition to the end, all interactions such as clicking on the screen are disabled.
+From the start of transition to the end, interactions of all containers such as clicking on the screen are disabled.
 
-You can change the settings to enable interaction during the transition.  
-To do this, set `Enable Interaction In Transition` in `UnityScreenNavigatorSettings` to `true`.
+You can change the settings by changing `Enable Interaction In Transition` and `Control Interactions Of All Containers` property of `UnityScreenNavigatorSettings`.
+In default, `Enable Interaction In Transition` is `false` and `Control Interactions Of All Containers` is `true`.
+
+To enable interaction during transitions, set `Enable Interaction In Transition` to `true`.
+And if you want to disable interaction only for the container that is currently transitioning, keep `Enable Interaction In Transition` to `false` and set `Control Interactions Of All Containers` to `false`.
 
 <p align="center">
-  <img width="60%" src="https://user-images.githubusercontent.com/47441314/137836806-6bbbb7dd-cc06-47aa-a1b8-3fe7d427f9fa.png">
+  <img width="60%" src="https://user-images.githubusercontent.com/47441314/200176139-4de8c94e-60f4-4db9-8abf-7b6d50bea09e.png">
 </p>
 
 You can create `UnityScreenNavigatorSettings` from `Assets > Create > Screen Navigator Settings`.

--- a/README_JA.md
+++ b/README_JA.md
@@ -875,13 +875,15 @@ yield return container.Pop(true);
 </p>
 
 #### 遷移中のインタラクションを有効にする
-遷移開始から終了までは、画面のクリックなどのインタラクションは全て無効になります。
+遷移開始から終了までは、全てのコンテナにおいて画面のクリックなどのインタラクションが無効になります。  
+この設定は`UnityScreenNavigatorSettings`の`Enable Interaction In Transition`と`Control Interactions Of All Containers`で変更できます。  
+デフォルトでは、`Enable Interaction In Transition`はfalseで、`Control Interactions Of All Containers`はtrueになっています。
 
-設定を変更すると、遷移中のインタラクションを有効にすることができます。  
-有効にするには`UnityScreenNavigatorSettings`の`Enable Interaction In Transition`をtrueに設定します。
+`UnityScreenNavigatorSettings`の`Enable Interaction In Transition`をtrueに設定すると、遷移中でもインタラクションが有効になります。  
+また`Enable Interaction In Transition`をfalseにしたまま`Control Interactions Of All Containers`をfalseにすると、遷移処理を行なっているコンテナのみインタラクションを無効にします。
 
 <p align="center">
-  <img width=500 src="https://user-images.githubusercontent.com/47441314/137836806-6bbbb7dd-cc06-47aa-a1b8-3fe7d427f9fa.png">
+  <img width="60%" src="https://user-images.githubusercontent.com/47441314/200176139-4de8c94e-60f4-4db9-8abf-7b6d50bea09e.png">
 </p>
 
 `UnityScreenNavigatorSettings`は`Assets > Create > Screen Navigator Settings`から作成できます。


### PR DESCRIPTION
* Add a option to disable the interactions of all containers during transitions.
* This option is active in default.
    * If you want to return to the default behavior before the update, uncheck `Control Interactions Of All Containers` in `UnityScreenNavigatorSettings`.

----

* 遷移中に全コンテナのインタラクションを無効にするオプション追加しました
* このオプションはデフォルトで有効になります
    * アップデート前のデフォルト挙動に戻したい場合は`UnityScreenNavigatorSettings`の`Control Interactions Of All Containers`のチェックを外してください