### PR TITLE
Fix Preloaded Asset Loader Object not work in editor

### DIFF
--- a/Assets/UnityScreenNavigator/Runtime/Foundation/AssetLoader/PreloadedAssetLoaderObject.cs
+++ b/Assets/UnityScreenNavigator/Runtime/Foundation/AssetLoader/PreloadedAssetLoaderObject.cs
@@ -10,15 +10,13 @@ namespace UnityScreenNavigator.Runtime.Foundation.AssetLoader
     {
         [SerializeField] private List<KeyAssetPair> _preloadedObjects = new List<KeyAssetPair>();
 
-        private readonly PreloadedAssetLoader _loader = new PreloadedAssetLoader();
+        private PreloadedAssetLoader _loader = new PreloadedAssetLoader();
 
         public List<KeyAssetPair> PreloadedObjects => _preloadedObjects;
 
         private void OnEnable()
         {
-            if (!Application.isPlaying)
-                return;
-
+            _loader = new PreloadedAssetLoader();
             foreach (var preloadedObject in _preloadedObjects)
             {
                 if (string.IsNullOrEmpty(preloadedObject.Key))
@@ -33,10 +31,8 @@ namespace UnityScreenNavigator.Runtime.Foundation.AssetLoader
 
         private void OnDisable()
         {
-            if (!Application.isPlaying)
-                return;
-
-            _loader.PreloadedObjects.Clear();
+            _loader?.PreloadedObjects.Clear();
+            _loader = null;
         }
 
         public override AssetLoadHandle<T> Load<T>(string key)

--- a/Assets/UnityScreenNavigator/Runtime/Foundation/AssetLoader/PreloadedAssetLoaderObject.cs
+++ b/Assets/UnityScreenNavigator/Runtime/Foundation/AssetLoader/PreloadedAssetLoaderObject.cs
@@ -10,13 +10,12 @@ namespace UnityScreenNavigator.Runtime.Foundation.AssetLoader
     {
         [SerializeField] private List<KeyAssetPair> _preloadedObjects = new List<KeyAssetPair>();
 
-        private PreloadedAssetLoader _loader = new PreloadedAssetLoader();
+        private readonly PreloadedAssetLoader _loader = new PreloadedAssetLoader();
 
         public List<KeyAssetPair> PreloadedObjects => _preloadedObjects;
 
         private void OnEnable()
         {
-            _loader = new PreloadedAssetLoader();
             foreach (var preloadedObject in _preloadedObjects)
             {
                 if (string.IsNullOrEmpty(preloadedObject.Key))
@@ -32,7 +31,6 @@ namespace UnityScreenNavigator.Runtime.Foundation.AssetLoader
         private void OnDisable()
         {
             _loader?.PreloadedObjects.Clear();
-            _loader = null;
         }
 
         public override AssetLoadHandle<T> Load<T>(string key)


### PR DESCRIPTION

### 状況

- Unity : 2019.4.29f1

PreloadedAssetLoaderを設定してUnityEditorで再生した場合、特定状況で `_loader.PreloadedObjects` にObjectが入っておらず、ページ遷移ができない。


### 原因

UnityEditor上のPreloadedAssetLoader.OnEnableは発生タイミングが状況に応じて変わる

- そのままPlayModeを実行すると、PlayMode中にUnityScreenNavigatorSettingsがインスタンス化され、参照されたPreloadedAssetLoaderがロードされ、OnEnableが呼ばれる(想定される正常ケース)
- Editor上でUnityScreenNavigatorSettings.assetもしくはPreloadedAssetLoader.assetを選択した場合、そのタイミングでロードされOnEnableが実行される

ロード済みのScriptableObjectはPlayMode再生時に一度`OnDisable`が呼ばれてから再度`OnEnable`が呼ばれるが、これはPlayMode中ではないらしく、 `Application.IsPlaying == false` となっていた

### 対応

`Application.IsPlaying` のバリデーションを外しました。
ただ、ScriptableObjectのOnEnableタイミングがハンドリングしにくいのは変わらないので、根本設計を変えるかLoad<T>が呼び出された時にランタイムに読み込むなどにした方がいいかもしれません。

refs

https://gamedev.stackexchange.com/questions/188224/scriptableobjects-events-execution-order

