### PR TITLE
Add Unity 6.5 compatibility for GetEntityId

### DIFF
--- a/Assets/UnityScreenNavigator/Runtime/Core/Modal/ModalContainer.cs
+++ b/Assets/UnityScreenNavigator/Runtime/Core/Modal/ModalContainer.cs
@@ -14,7 +14,11 @@ namespace UnityScreenNavigator.Runtime.Core.Modal
     [RequireComponent(typeof(RectMask2D))]
     public sealed class ModalContainer : MonoBehaviour, IScreenContainer
     {
+#if UNITY_6000_5_OR_NEWER
+        private static readonly Dictionary<EntityId, ModalContainer> InstanceCacheByTransform = new();
+#else
         private static readonly Dictionary<int, ModalContainer> InstanceCacheByTransform = new();
+#endif
 
         private static readonly Dictionary<string, ModalContainer> InstanceCacheByName = new();
 
@@ -101,7 +105,11 @@ namespace UnityScreenNavigator.Runtime.Core.Modal
             _orderedModalIds.Clear();
 
             InstanceCacheByName.Remove(_name);
+#if UNITY_6000_5_OR_NEWER
+            var keysToRemove = new List<EntityId>();
+#else
             var keysToRemove = new List<int>();
+#endif
             foreach (var cache in InstanceCacheByTransform)
                 if (Equals(cache.Value))
                     keysToRemove.Add(cache.Key);
@@ -141,7 +149,11 @@ namespace UnityScreenNavigator.Runtime.Core.Modal
         /// <returns></returns>
         public static ModalContainer Of(RectTransform rectTransform, bool useCache = true)
         {
+#if UNITY_6000_5_OR_NEWER
+            var id = rectTransform.GetEntityId();
+#else
             var id = rectTransform.GetInstanceID();
+#endif
             if (useCache && InstanceCacheByTransform.TryGetValue(id, out var container)) return container;
 
             container = rectTransform.GetComponentInParent<ModalContainer>();

--- a/Assets/UnityScreenNavigator/Runtime/Core/Page/PageContainer.cs
+++ b/Assets/UnityScreenNavigator/Runtime/Core/Page/PageContainer.cs
@@ -14,7 +14,11 @@ namespace UnityScreenNavigator.Runtime.Core.Page
     [RequireComponent(typeof(RectMask2D))]
     public sealed class PageContainer : MonoBehaviour, IScreenContainer
     {
+#if UNITY_6000_5_OR_NEWER
+        private static readonly Dictionary<EntityId, PageContainer> InstanceCacheByTransform = new();
+#else
         private static readonly Dictionary<int, PageContainer> InstanceCacheByTransform = new();
+#endif
 
         private static readonly Dictionary<string, PageContainer> InstanceCacheByName = new();
 
@@ -90,7 +94,11 @@ namespace UnityScreenNavigator.Runtime.Core.Page
             _orderedPageIds.Clear();
 
             InstanceCacheByName.Remove(_name);
+#if UNITY_6000_5_OR_NEWER
+            var keysToRemove = new List<EntityId>();
+#else
             var keysToRemove = new List<int>();
+#endif
             foreach (var cache in InstanceCacheByTransform)
                 if (Equals(cache.Value))
                     keysToRemove.Add(cache.Key);
@@ -130,7 +138,11 @@ namespace UnityScreenNavigator.Runtime.Core.Page
         /// <returns></returns>
         public static PageContainer Of(RectTransform rectTransform, bool useCache = true)
         {
+#if UNITY_6000_5_OR_NEWER
+            var id = rectTransform.GetEntityId();
+#else
             var id = rectTransform.GetInstanceID();
+#endif
             if (useCache && InstanceCacheByTransform.TryGetValue(id, out var container)) return container;
 
             container = rectTransform.GetComponentInParent<PageContainer>();

--- a/Assets/UnityScreenNavigator/Runtime/Core/Sheet/SheetContainer.cs
+++ b/Assets/UnityScreenNavigator/Runtime/Core/Sheet/SheetContainer.cs
@@ -14,8 +14,13 @@ namespace UnityScreenNavigator.Runtime.Core.Sheet
     [RequireComponent(typeof(RectMask2D))]
     public sealed class SheetContainer : MonoBehaviour, IScreenContainer
     {
+#if UNITY_6000_5_OR_NEWER
+        private static readonly Dictionary<EntityId, SheetContainer> InstanceCacheByTransform =
+            new Dictionary<EntityId, SheetContainer>();
+#else
         private static readonly Dictionary<int, SheetContainer> InstanceCacheByTransform =
             new Dictionary<int, SheetContainer>();
+#endif
 
         private static readonly Dictionary<string, SheetContainer> InstanceCacheByName =
             new Dictionary<string, SheetContainer>();
@@ -94,7 +99,11 @@ namespace UnityScreenNavigator.Runtime.Core.Sheet
             UnregisterAll();
 
             InstanceCacheByName.Remove(_name);
+#if UNITY_6000_5_OR_NEWER
+            var keysToRemove = new List<EntityId>();
+#else
             var keysToRemove = new List<int>();
+#endif
             foreach (var cache in InstanceCacheByTransform)
                 if (Equals(cache.Value))
                     keysToRemove.Add(cache.Key);
@@ -123,7 +132,11 @@ namespace UnityScreenNavigator.Runtime.Core.Sheet
         /// <returns></returns>
         public static SheetContainer Of(RectTransform rectTransform, bool useCache = true)
         {
+#if UNITY_6000_5_OR_NEWER
+            var hashCode = rectTransform.GetEntityId();
+#else
             var hashCode = rectTransform.GetInstanceID();
+#endif
 
             if (useCache && InstanceCacheByTransform.TryGetValue(hashCode, out var container)) return container;
 


### PR DESCRIPTION
Fixes #45

## Summary

This PR adds compatibility with Unity 6.5 by replacing `GetInstanceID()` with `GetEntityId()` where required.

To preserve compatibility with earlier Unity versions, conditional compilation is used:

- Unity 6.5 or newer: `GetEntityId()` / `EntityId`
- Unity 6.3 and 6.4: `GetInstanceID()` / `int`

## Changes

Updated the following classes:

- `PageContainer`
- `ModalContainer`
- `SheetContainer`

## Tested

- Unity 6.5: Compiles successfully
- Unity 6.4: Existing implementation is preserved through conditional compilation